### PR TITLE
FDL-732_persist_SWP+SD_ES_indices

### DIFF
--- a/helm/prod-values.yaml
+++ b/helm/prod-values.yaml
@@ -11,6 +11,8 @@ elasticsearchPublisher:
   image: elasticsearch
   tag: 5.6
   serviceName: elasticsearch
+  pvcSize: 4Gi
+  volumeName: es-publisher-storage
 
 elasticsearchSuperdesk:
   name: elastic-deployment
@@ -18,6 +20,8 @@ elasticsearchSuperdesk:
   image: elasticsearch
   tag: 2.4-alpine
   serviceName: elastic
+  pvcSize: 4Gi
+  volumeName: es-superdesk-storage
 
 memcached:
   name: memcached-deployment

--- a/helm/templates/elasticsearch-deployment.yaml
+++ b/helm/templates/elasticsearch-deployment.yaml
@@ -52,12 +52,8 @@ spec:
             - containerPort: 9300
           volumeMounts:
             - name: {{ .Values.elasticsearchPublisher.volumeName }}
-              mountPath: /usr/share/elasticsearch
-              subPath: data
+              mountPath: /usr/share/elasticsearch/data
           env:
             - name: TZ
               value: {{ .Values.timezone | quote }}
-          lifecycle:
-            postStart:
-              exec:
-                command: ["/bin/sh", "-c", "sleep 5 && rm -f /etc/localtime && ln -s /usr/share/zoneinfo/Europe/Berlin /etc/localtime"]
+

--- a/helm/templates/elasticsearch-deployment.yaml
+++ b/helm/templates/elasticsearch-deployment.yaml
@@ -11,6 +11,8 @@ spec:
     metadata:
       labels:
         component: {{ .Values.elasticsearchPublisher.component }}
+      annotations:
+        backup.velero.io/backup-volumes: {{ .Values.elasticsearchPublisher.volumeName }}
     spec:
       affinity:
         nodeAffinity:
@@ -31,6 +33,10 @@ spec:
                 operator: NotIn
                 values:
                 - database
+      volumes:
+        - name: {{ .Values.elasticsearchPublisher.volumeName }}
+          persistentVolumeClaim:
+            claimName: elasticsearch-publisher-persistent-volume-claim
       containers:
         - name: {{ .Values.elasticsearchPublisher.name }}
           image: "{{ .Values.elasticsearchPublisher.image }}:{{ .Values.elasticsearchPublisher.tag }}"
@@ -44,6 +50,10 @@ spec:
           ports:
             - containerPort: 9200
             - containerPort: 9300
+          volumeMounts:
+            - name: {{ .Values.elasticsearchPublisher.volumeName }}
+              mountPath: /usr/share/elasticsearch
+              subPath: data
           env:
             - name: TZ
               value: {{ .Values.timezone | quote }}

--- a/helm/templates/elasticsearch-sd-deployment.yaml
+++ b/helm/templates/elasticsearch-sd-deployment.yaml
@@ -11,26 +11,32 @@ spec:
     metadata:
       labels:
         component: {{ .Values.elasticsearchSuperdesk.component }}
+      annotations:
+        backup.velero.io/backup-volumes: {{ .Values.elasticsearchSuperdesk.volumeName }}
     spec:
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
-              - matchExpressions:
-                  - key: instance/type
-                    operator: NotIn
-                    values:
-                      - lb
-              - matchExpressions:
-                  - key: instance/type
-                    operator: NotIn
-                    values:
-                      - storage
-              - matchExpressions:
-                  - key: instance/type
-                    operator: NotIn
-                    values:
-                      - database
+            - matchExpressions:
+              - key: instance/type
+                operator: NotIn
+                values:
+                - lb
+            - matchExpressions:
+              - key: instance/type
+                operator: NotIn
+                values:
+                - storage
+            - matchExpressions:
+              - key: instance/type
+                operator: NotIn
+                values:
+                - database
+      volumes:
+        - name: {{ .Values.elasticsearchSuperdesk.volumeName }}
+          persistentVolumeClaim:
+            claimName: elasticsearch-sd-persistent-volume-claim
       containers:
         - name: {{ .Values.elasticsearchSuperdesk.component }}
           image: "{{ .Values.elasticsearchSuperdesk.image }}:{{ .Values.elasticsearchSuperdesk.tag }}"
@@ -43,6 +49,10 @@ spec:
               memory: 8Gi
           ports:
             - containerPort: 9200
+          volumeMounts:
+            - name: {{ .Values.elasticsearchSuperdesk.volumeName }}
+              mountPath: /usr/share/elasticsearch
+              subPath: data
           env:
             - name: TZ
               value: {{ .Values.timezone | quote }}

--- a/helm/templates/elasticsearch-sd-deployment.yaml
+++ b/helm/templates/elasticsearch-sd-deployment.yaml
@@ -51,8 +51,7 @@ spec:
             - containerPort: 9200
           volumeMounts:
             - name: {{ .Values.elasticsearchSuperdesk.volumeName }}
-              mountPath: /usr/share/elasticsearch
-              subPath: data
+              mountPath: /usr/share/elasticsearch/data
           env:
             - name: TZ
               value: {{ .Values.timezone | quote }}

--- a/helm/templates/persistent-volume-claims.yaml
+++ b/helm/templates/persistent-volume-claims.yaml
@@ -47,7 +47,7 @@ spec:
     - ReadWriteMany
   resources:
     requests:
-      storage: {{ .Values.publisher.pvcSize }}
+      storage: {{ .Values.elasticsearchSuperdesk.pvcSize }}
 
 ---
 
@@ -60,4 +60,4 @@ spec:
     - ReadWriteMany
   resources:
     requests:
-      storage: {{ .Values.publisher.pvcSize }}
+      storage: {{ .Values.elasticsearchPublisher.pvcSize }}

--- a/helm/templates/persistent-volume-claims.yaml
+++ b/helm/templates/persistent-volume-claims.yaml
@@ -34,3 +34,30 @@ spec:
   resources:
     requests:
       storage: {{ .Values.publisher.pvcSize }}
+
+
+---
+
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: elasticsearch-sd-persistent-volume-claim
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: {{ .Values.publisher.pvcSize }}
+
+---
+
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: elasticsearch-publisher-persistent-volume-claim
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: {{ .Values.publisher.pvcSize }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -11,6 +11,8 @@ elasticsearchPublisher:
   image: elasticsearch
   tag: 5.6
   serviceName: elasticsearch
+  pvcSize: 4Gi
+  volumeName: es-publisher-storage
 
 elasticsearchSuperdesk:
   name: elastic-deployment
@@ -18,6 +20,8 @@ elasticsearchSuperdesk:
   image: elasticsearch
   tag: 2.4-alpine
   serviceName: elastic
+  pvcSize: 4Gi
+  volumeName: es-superdesk-storage
 
 memcached:
   name: memcached-deployment


### PR DESCRIPTION
Wie von Mathias vorgeschlagen. Da Mehdi im Urlaub ist, wäre schön, wenn von ADO nochmal jemand drauf schaut.

Chart ist auf superdesk-stage deployed. Indizes sind auch noch nach re-deploy vorhanden, ohne dass sie aus sd / publisher neu aufgebaut werden müssen. 